### PR TITLE
Guard torch.distributed imports

### DIFF
--- a/fla/modules/fused_cross_entropy.py
+++ b/fla/modules/fused_cross_entropy.py
@@ -16,9 +16,12 @@ from fla.utils import input_guard
 # `_all_gather_base` and `_reduce_scatter_base`. They require the most recent
 # version of PyTorch. The following 2 lines are for backward compatibility with
 # older PyTorch.
-if "all_gather_into_tensor" not in dir(torch.distributed):
-    torch.distributed.all_gather_into_tensor = torch.distributed._all_gather_base
 
+try:
+    if "all_gather_into_tensor" not in dir(torch.distributed):
+        torch.distributed.all_gather_into_tensor = torch.distributed._all_gather_base
+except ImportError:
+    pass
 
 @triton.heuristics({
     "HAS_SMOOTHING": lambda args: args["label_smoothing"] > 0.0,

--- a/fla/modules/fused_cross_entropy.py
+++ b/fla/modules/fused_cross_entropy.py
@@ -20,7 +20,7 @@ from fla.utils import input_guard
 try:
     if "all_gather_into_tensor" not in dir(torch.distributed):
         torch.distributed.all_gather_into_tensor = torch.distributed._all_gather_base
-except ImportError:
+except AttributeError:
     pass
 
 @triton.heuristics({

--- a/fla/modules/fused_linear_cross_entropy.py
+++ b/fla/modules/fused_linear_cross_entropy.py
@@ -11,10 +11,14 @@ import torch.nn as nn
 import torch.nn.functional as F
 import triton
 import triton.language as tl
-from torch.distributed import DeviceMesh
-from torch.distributed.tensor import Replicate, Shard, distribute_module
-from torch.distributed.tensor.parallel import ParallelStyle
-
+try:
+    from torch.distributed import DeviceMesh
+    from torch.distributed.tensor import Replicate, Shard, distribute_module
+    from torch.distributed.tensor.parallel import ParallelStyle
+    ENABLE_DISTRIBUTED=True
+    
+except ImportError:
+    ENABLE_DISTRIBUTED = False
 from fla.ops.utils import logsumexp_fwd
 from fla.ops.utils.op import exp
 from fla.utils import input_guard, is_amd
@@ -566,55 +570,55 @@ class FusedLinearCrossEntropyLoss(nn.Module):
         )
         return loss
 
+if ENABLE_DISTRIBUTED:
+    class LinearLossParallel(ParallelStyle):
+        def __init__(
+            self,
+            *,
+            sequence_dim: int = 1,
+            use_local_output: bool = False,
+        ):
+            super().__init__()
 
-class LinearLossParallel(ParallelStyle):
-    def __init__(
-        self,
-        *,
-        sequence_dim: int = 1,
-        use_local_output: bool = False,
-    ):
-        super().__init__()
+            self.sequence_sharding = (Shard(sequence_dim),)
+            self.use_local_output = use_local_output
 
-        self.sequence_sharding = (Shard(sequence_dim),)
-        self.use_local_output = use_local_output
+        @staticmethod
+        def _prepare_input_fn(sequence_sharding, mod, inputs, device_mesh):
+            x, target, weight, bias = inputs
 
-    @staticmethod
-    def _prepare_input_fn(sequence_sharding, mod, inputs, device_mesh):
-        x, target, weight, bias = inputs
+            if not isinstance(x, DTensor):
+                # assume the input passed in already sharded on the sequence dim and create the DTensor
+                x = DTensor.from_local(x, device_mesh, sequence_sharding)
+            if x.placements != sequence_sharding:
+                x = x.redistribute(placements=sequence_sharding, async_op=True)
+            if not isinstance(target, DTensor):
+                target = DTensor.from_local(target, device_mesh, [Replicate()])
+            if target.placements != sequence_sharding:
+                target = target.redistribute(placements=sequence_sharding, async_op=True)
 
-        if not isinstance(x, DTensor):
-            # assume the input passed in already sharded on the sequence dim and create the DTensor
-            x = DTensor.from_local(x, device_mesh, sequence_sharding)
-        if x.placements != sequence_sharding:
-            x = x.redistribute(placements=sequence_sharding, async_op=True)
-        if not isinstance(target, DTensor):
-            target = DTensor.from_local(target, device_mesh, [Replicate()])
-        if target.placements != sequence_sharding:
-            target = target.redistribute(placements=sequence_sharding, async_op=True)
+            if not isinstance(weight, DTensor):
+                weight = DTensor.from_local(weight, device_mesh, [Replicate()])
+            if weight.placements != [Replicate()]:
+                # we replicate the weight/bias in FLCE
+                weight = weight.redistribute(placements=[Replicate()], async_op=True)
 
-        if not isinstance(weight, DTensor):
-            weight = DTensor.from_local(weight, device_mesh, [Replicate()])
-        if weight.placements != [Replicate()]:
-            # we replicate the weight/bias in FLCE
-            weight = weight.redistribute(placements=[Replicate()], async_op=True)
+            if bias is not None and not isinstance(bias, DTensor):
+                bias = DTensor.from_local(bias, device_mesh, [Replicate()])
+            if bias is not None and bias.placements != [Replicate()]:
+                bias = bias.redistribute(placements=[Replicate()], async_op=True)
 
-        if bias is not None and not isinstance(bias, DTensor):
-            bias = DTensor.from_local(bias, device_mesh, [Replicate()])
-        if bias is not None and bias.placements != [Replicate()]:
-            bias = bias.redistribute(placements=[Replicate()], async_op=True)
+            return x.to_local(), target.to_local(), weight.to_local(), bias.to_local() if bias is not None else bias
 
-        return x.to_local(), target.to_local(), weight.to_local(), bias.to_local() if bias is not None else bias
+        @staticmethod
+        def _prepare_output_fn(use_local_output, mod, outputs, device_mesh):
+            return outputs.to_local() if use_local_output else outputs
 
-    @staticmethod
-    def _prepare_output_fn(use_local_output, mod, outputs, device_mesh):
-        return outputs.to_local() if use_local_output else outputs
-
-    def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
-        return distribute_module(
-            module,
-            device_mesh,
-            partition_fn=None,
-            input_fn=partial(self._prepare_input_fn, self.sequence_sharding),
-            output_fn=partial(self._prepare_output_fn, self.use_local_output)
-        )
+        def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
+            return distribute_module(
+                module,
+                device_mesh,
+                partition_fn=None,
+                input_fn=partial(self._prepare_input_fn, self.sequence_sharding),
+                output_fn=partial(self._prepare_output_fn, self.use_local_output)
+            )

--- a/fla/modules/layernorm.py
+++ b/fla/modules/layernorm.py
@@ -20,10 +20,14 @@ import torch.nn.functional as F
 import triton
 import triton.language as tl
 from einops import rearrange
-from torch.distributed import DeviceMesh
-from torch.distributed.tensor import Replicate, Shard, distribute_module
-from torch.distributed.tensor.parallel import ParallelStyle
-
+try:
+    from torch.distributed import DeviceMesh
+    from torch.distributed.tensor import Replicate, Shard, distribute_module
+    from torch.distributed.tensor.parallel import ParallelStyle
+    ENABLE_DISTRIBUTED=True
+except ImportError:
+   ENABLE_DISTRIBUTED=False
+    
 from fla.utils import get_multiprocessor_count, input_guard
 
 try:
@@ -1380,54 +1384,54 @@ class RMSNormLinear(nn.Module):
             is_rms_norm=True
         )
 
+if ENABLE_DISTRIBUTED:
+    class NormParallel(ParallelStyle):
 
-class NormParallel(ParallelStyle):
+        def __init__(self, *, sequence_dim: int = 1, use_local_output: bool = False):
+            super().__init__()
+            self.sequence_sharding = (Shard(sequence_dim),)
+            self.use_local_output = use_local_output
 
-    def __init__(self, *, sequence_dim: int = 1, use_local_output: bool = False):
-        super().__init__()
-        self.sequence_sharding = (Shard(sequence_dim),)
-        self.use_local_output = use_local_output
-
-    def _replicate_module_fn(
-        self, name: str, module: nn.Module, device_mesh: DeviceMesh
-    ):
-        for p_name, param in module.named_parameters():
-            # simple replication with fixed ones_ init from LayerNorm/RMSNorm, which allow
-            # us to simply just use from_local
-            replicated_param = torch.nn.Parameter(
-                DTensor.from_local(param, device_mesh, [Replicate()], run_check=False)
-            )
-            module.register_parameter(p_name, replicated_param)
-
-    @staticmethod
-    def _prepare_input_fn(sequence_sharding, mod, inputs, device_mesh):
-        input_tensor = inputs[0]
-        if isinstance(input_tensor, DTensor):
-            # if the passed in input DTensor is not sharded on the sequence dim, we need to redistribute it
-            if input_tensor.placements != sequence_sharding:
-                input_tensor = input_tensor.redistribute(
-                    placements=sequence_sharding, async_op=True
+        def _replicate_module_fn(
+            self, name: str, module: nn.Module, device_mesh: DeviceMesh
+        ):
+            for p_name, param in module.named_parameters():
+                # simple replication with fixed ones_ init from LayerNorm/RMSNorm, which allow
+                # us to simply just use from_local
+                replicated_param = torch.nn.Parameter(
+                    DTensor.from_local(param, device_mesh, [Replicate()], run_check=False)
                 )
-            return input_tensor
-        elif isinstance(input_tensor, torch.Tensor):
-            # assume the input passed in already sharded on the sequence dim and create the DTensor
-            return DTensor.from_local(
-                input_tensor, device_mesh, sequence_sharding, run_check=False
-            )
-        else:
-            raise ValueError(
-                f"expecting input of {mod} to be a torch.Tensor or DTensor, but got {input_tensor}"
-            )
+                module.register_parameter(p_name, replicated_param)
 
-    @staticmethod
-    def _prepare_output_fn(use_local_output, mod, outputs, device_mesh):
-        return outputs.to_local() if use_local_output else outputs
+        @staticmethod
+        def _prepare_input_fn(sequence_sharding, mod, inputs, device_mesh):
+            input_tensor = inputs[0]
+            if isinstance(input_tensor, DTensor):
+                # if the passed in input DTensor is not sharded on the sequence dim, we need to redistribute it
+                if input_tensor.placements != sequence_sharding:
+                    input_tensor = input_tensor.redistribute(
+                        placements=sequence_sharding, async_op=True
+                    )
+                return input_tensor
+            elif isinstance(input_tensor, torch.Tensor):
+                # assume the input passed in already sharded on the sequence dim and create the DTensor
+                return DTensor.from_local(
+                    input_tensor, device_mesh, sequence_sharding, run_check=False
+                )
+            else:
+                raise ValueError(
+                    f"expecting input of {mod} to be a torch.Tensor or DTensor, but got {input_tensor}"
+                )
 
-    def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
-        return distribute_module(
-            module,
-            device_mesh,
-            self._replicate_module_fn,
-            partial(self._prepare_input_fn, self.sequence_sharding),
-            partial(self._prepare_output_fn, self.use_local_output),
-        )
+        @staticmethod
+        def _prepare_output_fn(use_local_output, mod, outputs, device_mesh):
+            return outputs.to_local() if use_local_output else outputs
+
+        def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
+            return distribute_module(
+                module,
+                device_mesh,
+                self._replicate_module_fn,
+                partial(self._prepare_input_fn, self.sequence_sharding),
+                partial(self._prepare_output_fn, self.use_local_output),
+            )

--- a/fla/modules/mlp.py
+++ b/fla/modules/mlp.py
@@ -8,10 +8,14 @@ from typing import TYPE_CHECKING, Any, Optional
 
 import torch
 import torch.nn as nn
-from torch.distributed import DeviceMesh
-from torch.distributed.tensor import Placement, Replicate, Shard, distribute_module
-from torch.distributed.tensor.parallel import ParallelStyle
 
+try:
+    from torch.distributed import DeviceMesh
+    from torch.distributed.tensor import Placement, Replicate, Shard, distribute_module
+    from torch.distributed.tensor.parallel import ParallelStyle
+    ENABLE_DISTRIBUTED=True
+except ImportError:
+    ENABLE_DISTRIBUTED=False
 from fla.modules.activations import swiglu, swiglu_linear
 
 try:
@@ -74,59 +78,59 @@ class SwiGLULinear(nn.Module):
     def forward(self, x, y, weight, bias):
         return swiglu_linear(x, y, weight, bias)
 
+if ENABLE_DISTRIBUTED:
+    class SwiGLULinearParallel(ParallelStyle):
+        def __init__(
+            self,
+            *,
+            input_layouts: Optional[Placement] = None,
+            output_layouts: Optional[Placement] = None,
+            use_local_output: bool = True,
+        ):
+            super().__init__()
+            self.input_layouts = (input_layouts or Shard(-1),)
+            self.output_layouts = (output_layouts or Replicate(),)
+            self.desired_input_layouts = (Shard(-1),)
+            self.use_local_output = use_local_output
 
-class SwiGLULinearParallel(ParallelStyle):
-    def __init__(
-        self,
-        *,
-        input_layouts: Optional[Placement] = None,
-        output_layouts: Optional[Placement] = None,
-        use_local_output: bool = True,
-    ):
-        super().__init__()
-        self.input_layouts = (input_layouts or Shard(-1),)
-        self.output_layouts = (output_layouts or Replicate(),)
-        self.desired_input_layouts = (Shard(-1),)
-        self.use_local_output = use_local_output
+        @staticmethod
+        def _prepare_input_fn(
+            input_layouts, desired_input_layouts, mod, inputs, device_mesh
+        ):
+            x, y, weight, bias = inputs
+            if not isinstance(x, DTensor):
+                x = DTensor.from_local(x, device_mesh, input_layouts, run_check=False)
+            if x.placements != desired_input_layouts:
+                x = x.redistribute(placements=desired_input_layouts, async_op=True)
 
-    @staticmethod
-    def _prepare_input_fn(
-        input_layouts, desired_input_layouts, mod, inputs, device_mesh
-    ):
-        x, y, weight, bias = inputs
-        if not isinstance(x, DTensor):
-            x = DTensor.from_local(x, device_mesh, input_layouts, run_check=False)
-        if x.placements != desired_input_layouts:
-            x = x.redistribute(placements=desired_input_layouts, async_op=True)
+            if not isinstance(y, DTensor):
+                y = DTensor.from_local(y, device_mesh, input_layouts, run_check=False)
+            if y.placements != desired_input_layouts:
+                y = y.redistribute(placements=desired_input_layouts, async_op=True)
 
-        if not isinstance(y, DTensor):
-            y = DTensor.from_local(y, device_mesh, input_layouts, run_check=False)
-        if y.placements != desired_input_layouts:
-            y = y.redistribute(placements=desired_input_layouts, async_op=True)
+            if not isinstance(weight, DTensor):
+                weight = DTensor.from_local(weight, device_mesh, (Shard(1),))
 
-        if not isinstance(weight, DTensor):
-            weight = DTensor.from_local(weight, device_mesh, (Shard(1),))
+            if bias is not None and not isinstance(bias, DTensor):
+                bias = DTensor.from_local(bias, device_mesh, (Replicate(),))
 
-        if bias is not None and not isinstance(bias, DTensor):
-            bias = DTensor.from_local(bias, device_mesh, (Replicate(),))
+            return x, y, weight, bias
 
-        return x, y, weight, bias
+        @staticmethod
+        def _prepare_output_fn(output_layouts, use_local_output, mod, outputs, device_mesh):
+            # Rowwise sharding produces partial output, depending on output layouts:
+            # 1. to replicate -> allreduce
+            # 2. to shard -> reduce_scatter
+            if outputs.placements != output_layouts:
+                outputs = outputs.redistribute(placements=output_layouts, async_op=True)
+            # back to local tensor if use_local_output is True
+            return outputs.to_local() if use_local_output else outputs
 
-    @staticmethod
-    def _prepare_output_fn(output_layouts, use_local_output, mod, outputs, device_mesh):
-        # Rowwise sharding produces partial output, depending on output layouts:
-        # 1. to replicate -> allreduce
-        # 2. to shard -> reduce_scatter
-        if outputs.placements != output_layouts:
-            outputs = outputs.redistribute(placements=output_layouts, async_op=True)
-        # back to local tensor if use_local_output is True
-        return outputs.to_local() if use_local_output else outputs
-
-    def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
-        return distribute_module(
-            module,
-            device_mesh,
-            partition_fn=None,
-            input_fn=partial(self._prepare_input_fn, self.input_layouts, self.desired_input_layouts),
-            output_fn=partial(self._prepare_output_fn, self.output_layouts, self.use_local_output)
-        )
+        def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
+            return distribute_module(
+                module,
+                device_mesh,
+                partition_fn=None,
+                input_fn=partial(self._prepare_input_fn, self.input_layouts, self.desired_input_layouts),
+                output_fn=partial(self._prepare_output_fn, self.output_layouts, self.use_local_output)
+            )


### PR DESCRIPTION
This PR adds guards to a few files around `torch.distributed`. This is because on some platforms, specifically Nvidia's torch containers for aarch64, `torch.distributed` does not contain the correct modules, so attempting to import them explodes.